### PR TITLE
feat: use netplan for managing wifi on the rg35xxplus

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A MinUI app that manages wifi connections.
 This pak is designed and tested on the following MinUI Platforms and devices:
 
 - `tg5040`: Trimui Brick (formerly `tg3040`), Trimui Smart Pro
-- `rg35xxplus`: RG-35XX Plus, RG-34XX, RG-35XX H, RG-35XX SP (needs wifi to be enabled on stock first)
+- `rg35xxplus`: RG-35XX Plus, RG-34XX, RG-35XX H, RG-35XX SP
 
 Use the correct platform for your device.
 

--- a/launch.sh
+++ b/launch.sh
@@ -155,8 +155,10 @@ show_message() {
 }
 
 write_config() {
-    cp "$progdir/res/wpa_supplicant.conf.tmpl" "$progdir/res/wpa_supplicant.conf"
     echo "Generating wpa_supplicant.conf..."
+    cp "$progdir/res/wpa_supplicant.conf.tmpl" "$progdir/res/wpa_supplicant.conf"
+    echo "Generating netplan.yaml..."
+    cp "$progdir/res/netplan.yaml.tmpl" "$progdir/res/netplan.yaml"
 
     if [ ! -f "$SDCARD_PATH/wifi.txt" ] && [ -f "$progdir/wifi.txt" ]; then
         mv "$progdir/wifi.txt" "$SDCARD_PATH/wifi.txt"
@@ -170,6 +172,7 @@ write_config() {
         return 1
     fi
 
+    has_passwords=false
     priority_used=false
     echo "" >>"$SDCARD_PATH/wifi.txt"
     while read -r line; do
@@ -194,6 +197,8 @@ write_config() {
             continue
         fi
 
+        has_passwords=true
+
         {
             echo "network={"
             echo "    ssid=\"$ssid\""
@@ -204,10 +209,18 @@ write_config() {
             fi
             echo "}"
         } >>"$progdir/res/wpa_supplicant.conf"
+        {
+            echo "                \"$ssid\":"
+            echo "                    password: \"$psk\""
+        } >>"$progdir/res/netplan.yaml"
     done <"$SDCARD_PATH/wifi.txt"
 
     if [ "$PLATFORM" = "rg35xxplus" ]; then
         cp "$progdir/res/wpa_supplicant.conf" /etc/wpa_supplicant/wpa_supplicant.conf
+        cp "$progdir/res/netplan.yaml" /etc/netplan/01-netcfg.yaml
+        if [ "$has_passwords" = false ]; then
+            rm -f /etc/netplan/01-netcfg.yaml
+        fi
     elif [ "$PLATFORM" = "tg5040" ]; then
         cp "$progdir/res/wpa_supplicant.conf" /etc/wifi/wpa_supplicant.conf
     else
@@ -237,7 +250,9 @@ wifi_enable() {
         ip link set wlan0 up
         iw dev wlan0 set power_save off
 
-        systemctl start wpa_supplicant
+        systemctl start wpa_supplicant || true
+        systemctl start systemd-networkd || true
+        netplan apply
     else
         show_message "$PLATFORM is not a supported platform" 2
         return 1
@@ -295,6 +310,10 @@ wifi_off() {
     fi
 
     cp "$progdir/res/wpa_supplicant.conf.tmpl" "$progdir/res/wpa_supplicant.conf"
+    if [ "$PLATFORM" = "rg35xxplus" ]; then
+        rm -f /etc/netplan/01-netcfg.yaml
+        netplan apply
+    fi
 }
 
 wifi_on() {

--- a/launch.sh
+++ b/launch.sh
@@ -295,6 +295,7 @@ wifi_off() {
     if pgrep wpa_supplicant; then
         echo "Stopping wpa_supplicant..."
         /etc/init.d/wpa_supplicant stop || true
+        systemctl stop wpa_supplicant || true
         killall -9 wpa_supplicant 2>/dev/null || true
     fi
 
@@ -313,6 +314,7 @@ wifi_off() {
     if [ "$PLATFORM" = "rg35xxplus" ]; then
         rm -f /etc/netplan/01-netcfg.yaml
         netplan apply
+        systemctl stop systemd-networkd || true
     fi
 }
 

--- a/res/netplan.yaml.tmpl
+++ b/res/netplan.yaml.tmpl
@@ -1,0 +1,8 @@
+---
+network:
+    version: 2
+    renderer: networkd
+    wifis:
+        wlan0:
+            dhcp4: true
+            access-points:


### PR DESCRIPTION
While we still write out wpa_supplicant files, we now also manage configuration via netplan, which is available for use on the rg35xxplus (ubuntu 22.04).

Note that unlike on the tg5040 - where MinUI disables wifi on start - the rg35xxplus family persists the wifi connection on boot.