### PR TITLE
feat: add the ability to start wifi on boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ bin/*
 !bin/.gitkeep
 res/fonts/*
 !res/fonts/.gitkeep
+
+!bin/wifi-enable
+!bin/wifi-enabled
+!bin/on-boot

--- a/bin/on-boot
+++ b/bin/on-boot
@@ -1,0 +1,12 @@
+#!/bin/sh
+bindir="$(dirname "$0")"
+
+main() {
+    "$bindir/wifi-enable" &
+}
+
+if [ -f "$LOGS_PATH/Wifi.txt" ]; then
+    mv "$LOGS_PATH/Wifi.txt" "$LOGS_PATH/Wifi.txt.old"
+fi
+
+main "$@" >"$LOGS_PATH/Wifi.txt" 2>&1

--- a/bin/wifi-enable
+++ b/bin/wifi-enable
@@ -1,0 +1,45 @@
+#!/bin/sh
+bindir="$(dirname "$0")"
+JQ="$bindir/jq-arm"
+if uname -m | grep -q '64'; then
+    JQ="$bindir/jq-arm64"
+fi
+
+main() {
+    if [ "$PLATFORM" = "tg3040" ] && [ -z "$DEVICE" ]; then
+        export DEVICE="brick"
+        export PLATFORM="tg5040"
+    fi
+
+    echo "Preparing to enable wifi..."
+    if [ "$PLATFORM" = "tg5040" ]; then
+        SYSTEM_JSON_PATH="/mnt/UDISK/system.json"
+        chmod +x "$JQ"
+        "$JQ" '.wifi = 1' "$SYSTEM_JSON_PATH" >"/tmp/system.json.tmp"
+        mv "/tmp/system.json.tmp" "$SYSTEM_JSON_PATH"
+    fi
+
+    echo "Unblocking wireless..."
+    rfkill unblock wifi || true
+
+    echo "Starting wpa_supplicant..."
+    if [ "$PLATFORM" = "tg5040" ]; then
+        /etc/init.d/wpa_supplicant stop || true
+        /etc/init.d/wpa_supplicant start || true
+        ( (udhcpc -i wlan0 -q &) &)
+    elif [ "$PLATFORM" = "rg35xxplus" ]; then
+        ip link set wlan0 up
+        iw dev wlan0 set power_save off
+
+        systemctl start wpa_supplicant || true
+        systemctl start systemd-networkd || true
+        netplan apply
+    else
+        echo "$PLATFORM is not a supported platform for Wifi.pak"
+        return 1
+    fi
+
+    ifconfig wlan0 up || true
+}
+
+main "$@"

--- a/bin/wifi-enabled
+++ b/bin/wifi-enabled
@@ -1,0 +1,35 @@
+#!/bin/sh
+bindir="$(dirname "$0")"
+JQ="$bindir/jq-arm"
+if uname -m | grep -q '64'; then
+    JQ="$bindir/jq-arm64"
+fi
+
+main() {
+    SYSTEM_JSON_PATH="/mnt/UDISK/system.json"
+    if [ -f "$SYSTEM_JSON_PATH" ]; then
+        chmod +x "$JQ"
+        wifi_enabled="$("$JQ" '.wifi' "$SYSTEM_JSON_PATH")"
+        if [ "$wifi_enabled" != "1" ]; then
+            return 1
+        fi
+    fi
+
+    wifi_status="$(rfkill list wifi || true)"
+    if echo "$wifi_status" | grep -q "blocked: yes"; then
+        return 1
+    fi
+
+    if ! pgrep wpa_supplicant; then
+        return 1
+    fi
+
+    # check if the device is on
+    if [ "$(cat /sys/class/net/wlan0/flags 2>/dev/null)" != "0x1003" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+main "$@"


### PR DESCRIPTION
When enabled, this will ensure there is a platform-specific auto.sh file. Once available, it will inject a start-on-boot stanza for the wifi pak, which will then enable the wireless network on boot (necessary on the Brick).

Closes #14