### PR TITLE
fix: workaround empty system.json when detecting wifi

### DIFF
--- a/bin/service-on
+++ b/bin/service-on
@@ -21,9 +21,16 @@ main() {
     echo "Preparing to enable wifi..."
     if [ "$PLATFORM" = "tg5040" ]; then
         SYSTEM_JSON_PATH="/mnt/UDISK/system.json"
-        chmod +x "$PAK_DIR/bin/$architecture/jq"
-        "$PAK_DIR/bin/$architecture/jq" '.wifi = 1' "$SYSTEM_JSON_PATH" >"/tmp/system.json.tmp"
-        mv "/tmp/system.json.tmp" "$SYSTEM_JSON_PATH"
+        [ ! -f "$SYSTEM_JSON_PATH" ] && echo '{"wifi": 0}' >"$SYSTEM_JSON_PATH"
+        [ ! -s "$SYSTEM_JSON_PATH" ] && echo '{"wifi": 0}' >"$SYSTEM_JSON_PATH"
+
+        if [ -x /usr/trimui/bin/systemval ]; then
+            /usr/trimui/bin/systemval set wifi 1
+        else
+            chmod +x "$PAK_DIR/bin/$architecture/jq"
+            jq '.wifi = 1' "$SYSTEM_JSON_PATH" >"/tmp/system.json.tmp"
+            mv "/tmp/system.json.tmp" "$SYSTEM_JSON_PATH"
+        fi
     fi
 
     echo "Unblocking wireless..."

--- a/bin/wifi-enabled
+++ b/bin/wifi-enabled
@@ -15,8 +15,17 @@ export PATH="$PAK_DIR/bin/$architecture:$PAK_DIR/bin/$PLATFORM:$PAK_DIR/bin:$PAT
 main() {
     SYSTEM_JSON_PATH="/mnt/UDISK/system.json"
     if [ -f "$SYSTEM_JSON_PATH" ]; then
-        chmod +x "$PAK_DIR/bin/$architecture/jq"
-        wifi_enabled="$("$PAK_DIR/bin/$architecture/jq" '.wifi' "$SYSTEM_JSON_PATH")"
+        [ ! -f "$SYSTEM_JSON_PATH" ] && echo '{"wifi": 0}' >"$SYSTEM_JSON_PATH"
+        [ ! -s "$SYSTEM_JSON_PATH" ] && echo '{"wifi": 0}' >"$SYSTEM_JSON_PATH"
+
+        wifi_enabled=0
+        if [ -x /usr/trimui/bin/systemval ]; then
+            wifi_enabled="$(/usr/trimui/bin/systemval wifi)"
+        else
+            chmod +x "$PAK_DIR/bin/$architecture/jq"
+            wifi_enabled="$(jq '.wifi' "$SYSTEM_JSON_PATH")"
+        fi
+
         if [ "$wifi_enabled" != "1" ]; then
             return 1
         fi

--- a/launch.sh
+++ b/launch.sh
@@ -275,8 +275,16 @@ wifi_off() {
     echo "Preparing to toggle wifi off..."
     if [ "$PLATFORM" = "tg5040" ]; then
         SYSTEM_JSON_PATH="/mnt/UDISK/system.json"
-        jq '.wifi = 0' "$SYSTEM_JSON_PATH" >"/tmp/system.json.tmp"
-        mv "/tmp/system.json.tmp" "$SYSTEM_JSON_PATH"
+        [ ! -f "$SYSTEM_JSON_PATH" ] && echo '{"wifi": 0}' >"$SYSTEM_JSON_PATH"
+        [ ! -s "$SYSTEM_JSON_PATH" ] && echo '{"wifi": 0}' >"$SYSTEM_JSON_PATH"
+
+        if [ -x /usr/trimui/bin/systemval ]; then
+            /usr/trimui/bin/systemval set wifi 0
+        else
+            chmod +x "$PAK_DIR/bin/$architecture/jq"
+            jq '.wifi = 0' "$SYSTEM_JSON_PATH" >"/tmp/system.json.tmp"
+            mv "/tmp/system.json.tmp" "$SYSTEM_JSON_PATH"
+        fi
     fi
 
     if pgrep wpa_supplicant; then


### PR DESCRIPTION
If the system.json is empty for some reason, initialize it with wifi disabled. Also prefer using systemval if it is available for retrieving the wifi setting.