### PR TITLE
fix: only exit early on show_message for the miyoo mini

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -164,7 +164,9 @@ show_message() {
 
     killall minui-presenter >/dev/null 2>&1 || true
     echo "$message" 1>&2
-    return 0
+    if [ "$PLATFORM" = "miyoomini" ]; then
+        return 0
+    fi
     if [ "$seconds" = "forever" ]; then
         minui-presenter --message "$message" --timeout -1 &
     else


### PR DESCRIPTION
The underlying minui-presenter issue has yet to be resolved but this shouldn't impact other devices.